### PR TITLE
add missing checks to caesar

### DIFF
--- a/caesar/__init__.py
+++ b/caesar/__init__.py
@@ -43,5 +43,15 @@ def checks_for_handling_non_alpha():
 
 @check50.check(compiles)
 def handles_no_argv():
-    """handles lack of argv[1]"""
+    """handles lack of key"""
     check50.run("./caesar").exit(1)
+    
+@check50.check(compiles)
+def handles_non_numeric_argv():
+    """handles non-numeric key"""
+    check50.run("./caesar 2x").exit(1)
+    
+@check50.check(compiles)
+def too_many_args():
+    """handles too many arguments"""
+    check50.run("./caesar 1 2").exit(1)


### PR DESCRIPTION
Added command-line checks for non-numeric key and more than one argument, both in the spec but not tested.