### PR TITLE
Tweak testing.c

### DIFF
--- a/runoff/testing.c
+++ b/runoff/testing.c
@@ -50,7 +50,7 @@ int main(int argc, string argv[])
             preferences[2][0] = preferences[3][0] = preferences[4][0] = 1;
             preferences[2][1] = preferences[3][1] = preferences[4][1] = 3;
             preferences[2][2] = preferences[3][2] = preferences[4][2] = 0;
-            preferences[2][2] = preferences[3][2] = preferences[4][2] = 2;
+            preferences[2][3] = preferences[3][3] = preferences[4][3] = 2;
             preferences[5][0] = 2;
             preferences[5][1] = 1;
             preferences[5][2] = 3;

--- a/runoff/testing.c
+++ b/runoff/testing.c
@@ -52,8 +52,8 @@ int main(int argc, string argv[])
             preferences[2][2] = preferences[3][2] = preferences[4][2] = 0;
             preferences[2][3] = preferences[3][3] = preferences[4][3] = 2;
             preferences[5][0] = 2;
-            preferences[5][1] = 1;
-            preferences[5][2] = 3;
+            preferences[5][1] = 3;
+            preferences[5][2] = 1;
             preferences[5][3] = 0;
             preferences[6][0] = 0;
             preferences[6][1] = 2;


### PR DESCRIPTION
I changed the voter preferences in order to fix an issue in check 50 where it doesn't check if the votes were counted properly in certain cases when multiple candidates are eliminated.

Now, when the check for tabulate3 runs in __init__.py, it checks to see if both the votes for the top two candidates that were eliminated for the last voter (Charlie & David) are not counted and instead it counts the vote of the third preference (Bob) who hasn't been eliminated.