### PR TITLE
Added extra check for substitution to cover edge case

### DIFF
--- a/substitution/__init__.py
+++ b/substitution/__init__.py
@@ -75,3 +75,8 @@ def handles_duplicate_chars():
 def handles_multiple_duplicate_chars():
     """handles multiple duplicate characters in key"""
     check50.run("./substitution BBCCEFGHIJKLMNOPQRSTUVWXYZ").exit(1)
+
+@check50.check(compiles)
+def handles_multiple_duplicate_mixed_case_chars():
+    """handles multiple duplicate characters with mixed cases in key"""
+    check50.run("./substitution BbCcEFGHIJKLMNOPQRSTUVWXYZ").exit(1)


### PR DESCRIPTION
This extra check covers the edge case of a student checking for exact equality between two characters in the key, and as such, letting through duplicate letters that are just different cases, such as B and b, or C and c.