### PR TITLE
Adds extra check for Plurality

### DIFF
--- a/plurality/__init__.py
+++ b/plurality/__init__.py
@@ -96,3 +96,9 @@ def print_winner4():
     result = check50.run("./plurality_test 0 11").stdout()
     if set(result.split("\n")) - {""} != {"Alice", "Bob", "Charlie"}:
         raise check50.Mismatch("Alice\nBob\nCharlie\n", result)
+
+@check50.check(compiles)
+@check50.hidden("print_winner function did not print only winners of election")
+def print_winner5():
+    """print_winner prints only winner name when losers tie"""
+    check50.run("./plurality_test 0 12").stdout("Charlie\n").exit(0)

--- a/plurality/testing.c
+++ b/plurality/testing.c
@@ -99,5 +99,12 @@ int main(int argc, string argv[])
             candidates[2].votes = 8;
             print_winner();
             break;
+            
+        case 12:
+            candidates[0].votes = 1;
+            candidates[1].votes = 1;
+            candidates[2].votes = 2;
+            print_winner();
+            break;
     }
 }


### PR DESCRIPTION
This extra check ensures that only the winner's name is printed, even if the losers tied, thus preventing some hack around logic, such as can be seen on my first check50 submission of the problem as an example.