### PR TITLE
Prevent overwriting of functions

### DIFF
--- a/challenges/speller/__init__.py
+++ b/challenges/speller/__init__.py
@@ -35,6 +35,11 @@ def compiles():
 def qualifies():
     """qualifies for Big Board"""
     try:
+        # make sure that dictionary.h doesn't override any functions used in speller.c
+        check50.run("""make dictionary.o && [ -z $(comm -12 \
+                       <(objdump -t  dictionary.o | awk '/.text/ { print $6 }' | sort) \
+                       <(objdump -t  speller.o | awk '/UND/ { print $4 }' | grep -v "check\|load\|unload\|size" | sort) ) ]").exit(0)""").exit(0)
+        
         # inject canary
         canary = str(uuid.uuid4())
         check50.run("sed -i -e 's/CANARY/{}/' speller.c".format(canary)).exit(0)

--- a/challenges/speller/__init__.py
+++ b/challenges/speller/__init__.py
@@ -38,7 +38,7 @@ def qualifies():
         # make sure that dictionary.h doesn't override any functions used in speller.c
         check50.run("""make dictionary.o && [ -z $(comm -12 \
                        <(objdump -t  dictionary.o | awk '/.text/ { print $6 }' | sort) \
-                       <(objdump -t  speller.o | awk '/UND/ { print $4 }' | grep -v "check\|load\|unload\|size" | sort) ) ]").exit(0)""").exit(0)
+                       <(objdump -t  speller.o | awk '/UND/ { print $4 }' | grep -v "check\|load\|unload\|size" | sort) ) ]""").exit(0)
         
         # inject canary
         canary = str(uuid.uuid4())


### PR DESCRIPTION
This prevents `dictionary.c` from overrides any functions that are called in speller.c other than `check`, `load`, `unload` and `size`, as detailed in #56.

I wasn't able to test this in python, though I made sure that the bash script is correct, assuming that all called programs behave the same on the server as in `cs50 IDE`.

This doesn't fix all of the problems as one can probably still override the strings used in `speller.c` using inline assembly and the output of `objdump -t speller.o`.
Furthermore, one can still probe the stack for the `time_*` variables and modify them that way.