### PR TITLE
Add more tests for credit

### DIFF
--- a/sentimental/credit/__init__.py
+++ b/sentimental/credit/__init__.py
@@ -40,3 +40,12 @@ def test7():
     """identifies 1234567890 as INVALID"""
     check50.run("python3 credit.py").stdin("1234567890").stdout("INVALID\n").exit()
 
+@check50.check(exists)
+def test8():
+    """identifies 4111111111111113 as INVALID"""
+    check50.run("python3 credit.py").stdin("4111111111111113").stdout("INVALID\n").exit()
+
+@check50.check(exists)
+def test9():
+    """identifies 4222222222223 as INVALID"""
+    check50.run("python3 credit.py").stdin("4222222222223").stdout("INVALID\n").exit()


### PR DESCRIPTION
Added more tests for credit

A simple regex match was able to pass all checks, without actually implementing the Luhn algorithm.
Not quite sure if it was intended to be this way.

```py
american = re.compile(r"3(4|7)\d{13}")
master = re.compile(r"5[1-5]\d{14}")
visa = re.compile(r"4\d{12}(\d{3})?")
```