### PR TITLE
fix typo in new check

### DIFF
--- a/substitution/__init__.py
+++ b/substitution/__init__.py
@@ -57,6 +57,11 @@ def handles_no_argv():
     check50.run("./substitution").exit(1)
 
 @check50.check(compiles)
+def handles_too_many_args():
+    """handles too many arguments"""
+    check50.run("/substitution abcdefghijklmnopqrstuvwxyz abc").exit(1)
+    
+@check50.check(compiles)
 def handles_invalid_length():
     """handles invalid key length"""
     check50.run("./substitution QTXDGMKIPV").exit(1)


### PR DESCRIPTION
add back the `too_many_args` check but with the typo fixed!