### PR TITLE
improved re.sub specificity

### DIFF
--- a/cash/__init__.py
+++ b/cash/__init__.py
@@ -17,7 +17,7 @@ def compiles():
     check50.c.compile("cash.c", lcs50=True)
     
     # Rename main function to "distro_main"
-    cash = re.sub("int\s+main", "int distro_main", open("cash.c").read())
+    cash = re.sub("int\s+main\s*\(", "int distro_main(", open("cash.c").read())
 
     # Read testing file
     testing = open("testing.c").read()

--- a/plurality/__init__.py
+++ b/plurality/__init__.py
@@ -13,7 +13,7 @@ def exists():
 def compiles():
     """plurality compiles"""
     check50.c.compile("plurality.c", lcs50=True)
-    plurality = re.sub("int\s+main", "int distro_main", open("plurality.c").read())
+    plurality = re.sub("int\s+main\s*\(", "int distro_main(", open("plurality.c").read())
     testing = open("testing.c").read()
     with open("plurality_test.c", "w") as f:
         f.write(plurality)

--- a/runoff/__init__.py
+++ b/runoff/__init__.py
@@ -14,7 +14,7 @@ def exists():
 def compiles():
     """runoff compiles"""
     check50.c.compile("runoff.c", lcs50=True)
-    runoff = re.sub("int\s+main", "int distro_main", open("runoff.c").read())
+    runoff = re.sub("int\s+main\s*\(", "int distro_main(", open("runoff.c").read())
     testing = open("testing.c").read()
     with open("runoff_test.c", "w") as f:
         f.write(runoff)

--- a/tideman/__init__.py
+++ b/tideman/__init__.py
@@ -14,7 +14,7 @@ def exists():
 def compiles():
     """tideman compiles"""
     check50.c.compile("tideman.c", lcs50=True)
-    tideman = re.sub("int\s+main", "int distro_main", open("tideman.c").read())
+    tideman = re.sub("int\s+main\s*\(", "int distro_main(", open("tideman.c").read())
     testing = open("testing.c").read()
     with open("tideman_test.c", "w") as f:
         f.write(tideman)


### PR DESCRIPTION
Discovered in the cs50x discord server that certain cases where variables or functions that began with "int main" such as "int main_source" would cause the compile tests to fail for these 4 problems. Including a slightly longer, more-specific regex pattern and replacement string seems to be a good fix.