### PR TITLE
Replaced CS50P test case

### DIFF
--- a/plates/__init__.py
+++ b/plates/__init__.py
@@ -45,9 +45,9 @@ def test_CS05():
     
 # Numbers before letters (after the first 2 letters)
 @check50.check(exists)
-def test_CS50P():
-    """input of CS50P yields output of Invalid"""
-    input = "CS50P"
+def test_CS50P2():
+    """input of CS50P2 yields output of Invalid"""
+    input = "CS50P2"
     output = "Invalid"
     check50.run("python3 plates.py").stdin(input, prompt=True).stdout(regex(output), output, regex=True).exit()
 


### PR DESCRIPTION
Reasoning for the change
`CS50P` allows the student to simply check the last character.
```py
for i in range(len(plate)):
    if plate[i].isnumeric():
        if (plate[i] == "0" or plate[-1].isalpha()):
            return False
        else:
            break
```
`CS50P2` requires the user to check a range of characters after the number.

I think that this is a better test case to check the "Numbers cannot be in the middle" rule.