### PR TITLE
changed `seasons` classmethod patch

### DIFF
--- a/seasons/testing.py
+++ b/seasons/testing.py
@@ -3,7 +3,8 @@ import seasons
 
 # Create subclass of date class with patched method, today
 class mockDate(date):
-    def today():
+    @classmethod
+    def today(cls):
         return date(2000, 1, 1)
 
 


### PR DESCRIPTION
[date.today()](https://docs.python.org/3/library/datetime.html#datetime.date.today) is a classmethod, so it's available via both, the class and any instance of the class.  
This code would break the previous patch implementation, because it lacked the decorator and positional argument.
```py
d = date(year, month, day)
d.today()
```
