### PR TITLE
Allow period at the end of the output in `adieu`

### DIFF
--- a/adieu/__init__.py
+++ b/adieu/__init__.py
@@ -92,8 +92,8 @@ def test_six_names():
 
 
 def regex(text):
-    """match case-sensitively with any characters preceding and only whitespace after"""
-    return fr'^.*{escape(text)}\s*$'
+    """match case-sensitively with any characters preceding and only 1 period and whitespace after"""
+    return fr'^.*{escape(text)}\.?\s*$'
 
 
 def multi_name_test(input, output):


### PR DESCRIPTION
Added an optional period to the output regex checker function.
This task mentions grammatical correctness, so students often add a period at the end of the output.