### PR TITLE
Plurality, Runoff & Tideman fix for string direct comparison false positive.

### DIFF
--- a/plurality/testing.c
+++ b/plurality/testing.c
@@ -10,17 +10,22 @@ int main(int argc, string argv[])
     // Determine which test to run
     int setup = atoi(argv[1]);
     int test = atoi(argv[2]);
+    
+    //Candidate names initlised as none string literals
+    char alice[] = "Alice";
+    char bob[] = "Bob";
+    char charlie[] = "Charlie";
 
     // Setup
     switch (setup)
     {
         case 0:
             candidate_count = 3;
-            candidates[0].name = "Alice";
+            candidates[0].name = alice;
             candidates[0].votes = 0;
-            candidates[1].name = "Bob";
+            candidates[1].name = bob;
             candidates[1].votes = 0;
-            candidates[2].name = "Charlie";
+            candidates[2].name = charlie;
             candidates[2].votes = 0;
             break;
     }

--- a/runoff/testing.c
+++ b/runoff/testing.c
@@ -11,19 +11,25 @@ int main(int argc, string argv[])
     int setup = atoi(argv[1]);
     int test = atoi(argv[2]);
 
+    //Candidate names initlised as none string literals
+    char alice[] = "Alice";
+    char bob[] = "Bob";
+    char charlie[] = "Charlie";
+    char david[] = "David";
+
     // Setup
     switch (setup)
     {
         case 0:
             voter_count = 5;
             candidate_count = 3;
-            candidates[0].name = "Alice";
+            candidates[0].name = alice;
             candidates[0].votes = 0;
             candidates[0].eliminated = false;
-            candidates[1].name = "Bob";
+            candidates[1].name = bob;
             candidates[1].votes = 0;
             candidates[1].eliminated = false;
-            candidates[2].name = "Charlie";
+            candidates[2].name = charlie;
             candidates[2].votes = 0;
             candidates[2].eliminated = false;
             break;
@@ -31,16 +37,16 @@ int main(int argc, string argv[])
         case 1:
             voter_count = 7;
             candidate_count = 4;
-            candidates[0].name = "Alice";
+            candidates[0].name = alice;
             candidates[0].votes = 0;
             candidates[0].eliminated = false;
-            candidates[1].name = "Bob";
+            candidates[1].name = bob;
             candidates[1].votes = 0;
             candidates[1].eliminated = false;
-            candidates[2].name = "Charlie";
+            candidates[2].name = charlie;
             candidates[2].votes = 0;
             candidates[2].eliminated = false;
-            candidates[3].name = "David";
+            candidates[3].name = david;
             candidates[3].votes = 0;
             candidates[3].eliminated = false;
             preferences[0][0] = preferences[1][0] = 0;
@@ -64,16 +70,16 @@ int main(int argc, string argv[])
         case 2:
             voter_count = 28;
             candidate_count = 4;
-            candidates[0].name = "Alice";
+            candidates[0].name = alice;
             candidates[0].votes = 8;
             candidates[0].eliminated = false;
-            candidates[1].name = "Bob";
+            candidates[1].name = bob;
             candidates[1].votes = 15;
             candidates[1].eliminated = false;
-            candidates[2].name = "Charlie";
+            candidates[2].name = charlie;
             candidates[2].votes = 4;
             candidates[2].eliminated = false;
-            candidates[3].name = "David";
+            candidates[3].name = david;
             candidates[3].votes = 1;
             candidates[3].eliminated = false;
             break;

--- a/tideman/testing.c
+++ b/tideman/testing.c
@@ -11,14 +11,22 @@ int main(int argc, string argv[])
     int setup = atoi(argv[1]);
     int test = atoi(argv[2]);
 
+    //Candidate names initlised as none string literals
+    char alice[] = "Alice";
+    char bob[] = "Bob";
+    char charlie[] = "Charlie";
+    char david[] = "David";
+    char eric[] = "Eric";
+    char frank[] = "Frank";
+
     // Setup
     switch (setup)
     {
         case 0:
             candidate_count = 3;
-            candidates[0] = "Alice";
-            candidates[1] = "Bob";
-            candidates[2] = "Charlie";
+            candidates[0] = alice;
+            candidates[1] = bob;
+            candidates[2] = charlie;
             for (int i = 0; i < candidate_count; i++)
                 for (int j = 0; j < candidate_count; j++)
                     preferences[i][j] = 0;
@@ -72,29 +80,29 @@ int main(int argc, string argv[])
 
         case 4:
             candidate_count = 4;
-            candidates[0] = "Alice";
-            candidates[1] = "Bob";
-            candidates[2] = "Charlie";
-            candidates[3] = "David";
+            candidates[0] = alice;
+            candidates[1] = bob;
+            candidates[2] = charlie;
+            candidates[3] = david;
             break;
 
         case 5:
             candidate_count = 5;
-            candidates[0] = "Alice";
-            candidates[1] = "Bob";
-            candidates[2] = "Charlie";
-            candidates[3] = "David";
-            candidates[4] = "Erin";
+            candidates[0] = alice;
+            candidates[1] = bob;
+            candidates[2] = charlie;
+            candidates[3] = david;
+            candidates[4] = eric;
             break;
 
         case 6:
             candidate_count = 6;
-            candidates[0] = "Alice";
-            candidates[1] = "Bob";
-            candidates[2] = "Charlie";
-            candidates[3] = "David";
-            candidates[4] = "Eric";
-            candidates[5] = "Frank";
+            candidates[0] = alice;
+            candidates[1] = bob;
+            candidates[2] = charlie;
+            candidates[3] = david;
+            candidates[4] = eric;
+            candidates[5] = frank;
             break;
     }
 


### PR DESCRIPTION
Fix for issue #121  "Plurality, Runoff & Tideman tests fail to catch direct comparison of strings in vote()"

Modified tests to use character arrays ( none string literals ) for setting up the data.
Tested with code that should fail, but previously passed, and with code that should pass.