### PR TITLE
non-alphabetical key

### DIFF
--- a/substitution/__init__.py
+++ b/substitution/__init__.py
@@ -89,7 +89,7 @@ def handles_invalid_length():
 @check50.check(compiles)
 def handles_invalid_key_chars():
     """handles invalid characters in key"""
-    check50.run("./substitution ZWGKPMJRYISHFEXQON2DLUACVT").exit(1)
+    check50.run("./substitution ZWGKPMJ^YISHFEXQON[DLUACVT").exit(1)
 
 
 @check50.check(compiles)


### PR DESCRIPTION
I have replaced the 2 (and another character) in the key with [ and ^, two characters that are between A and z in the ASCII table.
this might catch faulty implementations with checks similar to `if (key[i] < 'A' && key[i] > 'z')`