### PR TITLE
Adding to Line 165 in testing.c in runoff

### DIFF
--- a/runoff/testing.c
+++ b/runoff/testing.c
@@ -162,6 +162,7 @@ int main(int argc, string argv[])
 
         case 14:
             candidates[3].eliminated = true;
+            candidates[3].votes = 0;
             candidates[2].votes = 5;
             printf("%i", find_min());
             break;


### PR DESCRIPTION
Setting candidates[2] votes to 5 goes over the total amount of voters that the test case sets, which is 29 instead of 28. Setting candidates[3] bool to eliminated does not reset the votes for that candidate, so the total amount of votes for candidate[3] is still 1. This produces some type of error rather than the desired output of "5" which _init_.py declares as the output for this case. I just added candidates[3] votes to be 0 so that the the total amount of votes doesn't go over 28.