### PR TITLE
update recover valgrind test

### DIFF
--- a/recover/__init__.py
+++ b/recover/__init__.py
@@ -95,4 +95,7 @@ def last_image():
 @check50.check(last_image)
 def memory():
     """program is free of memory errors"""
-    check50.c.valgrind("./recover card.raw").exit(0, timeout=10)
+    code = check50.c.valgrind("./recover card.raw").exit(timeout=10)
+    if code != 0:
+        raise check50.Failure("valgrind returned a segfault")
+


### PR DESCRIPTION
Captured the segfault to give a friendlier result message.  A non-zero code (like 134 or 139) means that valgrind crashed with a segfault.  Other memory errors are raised directly by `check50.c.valgrind`