### PR TITLE
Improve Regex, Help Messages in Einstein

### DIFF
--- a/einstein/__init__.py
+++ b/einstein/__init__.py
@@ -1,22 +1,75 @@
 import check50
 import re
 
+
 @check50.check()
 def exists():
     """einstein.py exists"""
     check50.exists("einstein.py")
 
+
 @check50.check(exists)
 def test1():
     """input of 1 yields output of 90000000000000000"""
-    output = check50.run("python3 einstein.py").stdin("1", prompt=False).stdout(r'(90,?0{3},?0{3},?0{3}.?(0+)?)|(90.?0{3}.?0{3}.?0{3},?(0+)?)', "90000000000000000").exit()
+    output = check50.run("python3 einstein.py").stdin("1", prompt=False).stdout()
+
+    # Extract number from stdout
+    match = re.search(r"([.,]?(?:\d[.,]?)+)", output)
+    if match is None:
+        raise check50.Failure("Looks like your program didn't output a number!")
+    number = match.group(0)
+
+    # Match correct number
+    if not re.match(r"^90(?:,?0{3}){5}(?:\.0+)?$", number) and not re.match(
+        r"^90(?:\.?0{3}){5}(?:,0+)?$", number
+    ):
+        raise check50.Mismatch(
+            "90000000000000000",
+            number,
+            help="Seems like your output might not be the right number!",
+        )
+
 
 @check50.check(exists)
 def test14():
     """input of 14 yields output of 1260000000000000000"""
-    check50.run("python3 einstein.py").stdin("14", prompt=False).stdout(r'(1,?260,?0{3},?0{3},?0{3},?0{3},?0{3}.?(0+)?)|(1.?260.?0{3}.?0{3}.?0{3}.?0{3}.?0{3},?(0+)?)',"1260000000000000000").exit()
+    output = check50.run("python3 einstein.py").stdin("14", prompt=False).stdout()
+
+    # Extract number from stdout
+    match = re.search(r"([.,]?(?:\d[.,]?)+)", output)
+    if match is None:
+        raise check50.Failure("Looks like your program didn't output a number!")
+    number = match.group(0)
+
+    # Match correct number
+    if not re.match(r"^1,?260(?:,?0{3}){5}(?:\.0+)?$", number) and not re.match(
+        r"1\.?260(?:\.?0{3}){5}(?:,0+)?$", number
+    ):
+        raise check50.Mismatch(
+            "1260000000000000000",
+            number,
+            help="Seems like your output might not be the right number!",
+        )
+
 
 @check50.check(exists)
 def test50():
     """input of 50 yields output of 4500000000000000000"""
-    check50.run("python3 einstein.py").stdin("50", prompt=False).stdout(r'(4,?500,?0{3},?0{3},?0{3},?0{3},?0{3}.?(0+)?)|(4.?500.?0{3}.?0{3}.?0{3}.?0{3}.?0{3},?(0+)?)', "4500000000000000000").exit()
+
+    output = check50.run("python3 einstein.py").stdin("50", prompt=False).stdout()
+
+    # Extract number from stdout
+    match = re.search(r"([.,]?(?:\d[.,]?)+)", output)
+    if match is None:
+        raise check50.Failure("Looks like your program didn't output a number!")
+    number = match.group(0)
+
+    # Match correct number
+    if not re.match(r"^4,?500(?:,?0{3}){5}(?:\.0+)?$", number) and not re.match(
+        r"^4\.?500(?:\.?0{3}){5}(?:,0+)?$", number
+    ):
+        raise check50.Mismatch(
+            "4500000000000000000",
+            number,
+            help="Seems like your output might not be the right number!",
+        )

--- a/einstein/__init__.py
+++ b/einstein/__init__.py
@@ -55,7 +55,6 @@ def test14():
 @check50.check(exists)
 def test50():
     """input of 50 yields output of 4500000000000000000"""
-
     output = check50.run("python3 einstein.py").stdin("50", prompt=False).stdout()
 
     # Extract number from stdout


### PR DESCRIPTION
This PR...
* Corrects the regular expressions used to match student output in Einstein
* Removes extraneous output from the error text, to focus exclusively on the difference between a student's outputted number and the expected number

*Mismatch between student's outputted number and the expected number*
<img width="500" alt="Screenshot 2023-05-31 at 10 17 49 AM" src="https://github.com/cs50/problems/assets/5281090/fef1b41f-e037-4d44-9161-d5e12370be79">

*No number output at all*
<img width="504" alt="Screenshot 2023-05-31 at 10 18 07 AM" src="https://github.com/cs50/problems/assets/5281090/366d16f7-d4ae-4902-ad23-8bcea7a72672">
