### PR TITLE
Update tests for wordle

### DIFF
--- a/wordle/__init__.py
+++ b/wordle/__init__.py
@@ -104,5 +104,5 @@ def partial_multiple_matches():
 @check50.check(compiles)
 def exact_match():
     """wordle recognizes correct guess"""
-    for word in ["gnome", "sized", "world", "miami"]:
+    for word in ["gnome", "sized", "world", "grill"]:
         check50.c.run(f"./wordle_test check_word {word} {word}").stdout(10)

--- a/wordle/__init__.py
+++ b/wordle/__init__.py
@@ -104,5 +104,5 @@ def partial_multiple_matches():
 @check50.check(compiles)
 def exact_match():
     """wordle recognizes correct guess"""
-    for word in ["gnome", "sized", "world"]:
+    for word in ["gnome", "sized", "world", "miami"]:
         check50.c.run(f"./wordle_test check_word {word} {word}").stdout(10)


### PR DESCRIPTION
# What

Update tests for wordle to verify the program's behavior on words with repeating letters

# Why

My first version of wordle (`wordle_bug.c`) didn't correctly handle words with repeating letters:

<img width="532" alt="image" src="https://github.com/cs50/problems/assets/178154/d3de5011-ea65-4e90-ae9b-5085b04995fb">

The existing test didn't catch the problem but the test modified in this PR does:

<img width="850" alt="image" src="https://github.com/cs50/problems/assets/178154/cfce48d2-b417-43d5-be4e-2b617d2bb730">

The modified test also works OK on the correct version of the program (`wordle_correct.c`):

<img width="880" alt="image" src="https://github.com/cs50/problems/assets/178154/f0271040-1c17-4cca-8293-0f2d7eee512b">

Finally, the correct version of the program also works correctly with hardcoded `grill`:

<img width="481" alt="image" src="https://github.com/cs50/problems/assets/178154/9cf18185-6b69-4407-b32b-a872d18776f5">

# Notes

I am attaching all the files used for testing this PR in [wordle_source.zip](https://github.com/cs50/problems/files/12447956/wordle_source.zip):

- `wordle_bug.c` - a version of the program with a bug. It passes the original test but fails the modified test
- `wordle_bug_grill.c`- same as `wordle_bug.c` but hardcodes `choice` to `grill`
- `wordle_correct.c` - a version of the program without the bug. It passes both original and modified test
- `wordle_correct_grill.c` - same as `wordle_correct.c` but hardcodes `choice` to `grill`




