### PR TITLE
Update __init__.py

### DIFF
--- a/census/__init__.py
+++ b/census/__init__.py
@@ -52,7 +52,7 @@ def test_view(db: SQL, filename: Path) -> None:
 
         # Check for intent
         if not re.search(
-            rf'^CREATE\s+VIEW\s+"?{re.escape(view_name)}"?', statement, re.IGNORECASE
+            rf'CREATE\s+VIEW\s+"?{re.escape(view_name)}"?', statement, re.IGNORECASE
         ):
             raise check50.Failure(
                 f'{filename} does not create a view named "{view_name}"'


### PR DESCRIPTION
remove the regex requirement for `CREATE` statement to begin at the very top of the `.sql` file.  (It will fail if there are comments atop the file)
@CarterZenke please review. Wasn't sure if there was a reason we needed that in the regex. My own files all failed because I had comments. ;)