### PR TITLE
Update __init__.py

### DIFF
--- a/plurality/__init__.py
+++ b/plurality/__init__.py
@@ -2,6 +2,7 @@ import check50
 import check50.c
 import re
 
+
 @check50.check()
 def exists():
     """plurality.c exists"""
@@ -21,11 +22,13 @@ def compiles():
         f.write(testing)
     check50.c.compile("plurality_test.c", lcs50=True)
 
+
 @check50.check(compiles)
 @check50.hidden("vote function did not return true")
 def vote_finds_name_first():
     """vote returns true when given name of first candidate"""
     check50.run("./plurality_test 0 0").stdout("true").exit(0)
+
 
 @check50.check(compiles)
 @check50.hidden("vote function did not return true")
@@ -33,11 +36,13 @@ def vote_finds_name_middle():
     """vote returns true when given name of middle candidate"""
     check50.run("./plurality_test 0 1").stdout("true").exit(0)
 
+
 @check50.check(compiles)
 @check50.hidden("vote function did not return true")
 def vote_finds_name_last():
     """vote returns true when given name of last candidate"""
     check50.run("./plurality_test 0 2").stdout("true").exit(0)
+
 
 @check50.check(compiles)
 @check50.hidden("vote function did not return false")
@@ -45,11 +50,13 @@ def vote_returns_false():
     """vote returns false when given name of invalid candidate"""
     check50.run("./plurality_test 0 3").stdout("false").exit(0)
 
+
 @check50.check(compiles)
 @check50.hidden("vote function did not correctly update vote totals")
 def first_vote_totals_correct():
     """vote produces correct counts when all votes are zero"""
     check50.run("./plurality_test 0 4").stdout("1 0 0").exit(0)
+
 
 @check50.check(compiles)
 @check50.hidden("vote function did not correctly update vote totals")
@@ -57,14 +64,15 @@ def subsequent_vote_totals_correct():
     """vote produces correct counts after some have already voted"""
     check50.run("./plurality_test 0 5").stdout("2 8 0").exit(0)
 
+
 @check50.check(compiles)
 @check50.hidden("vote function modified vote totals incorrectly")
 def invalid_vote_votes_unchanged():
     """vote leaves vote counts unchanged when voting for invalid candidate"""
     check50.run("./plurality_test 0 6").stdout("2 8 0").exit(0)
 
+
 @check50.check(compiles)
-# @check50.hidden("print_winner function did not print winner of election")
 def print_winner0():
     """print_winner identifies Alice as winner of election"""
     out = check50.run("./plurality_test 0 7").stdout()
@@ -72,7 +80,6 @@ def print_winner0():
 
 
 @check50.check(compiles)
-# @check50.hidden("print_winner function did not print winner of election")
 def print_winner1():
     """print_winner identifies Bob as winner of election"""
     out = check50.run("./plurality_test 0 8").stdout()
@@ -80,7 +87,6 @@ def print_winner1():
 
 
 @check50.check(compiles)
-# @check50.hidden("print_winner function did not print winner of election")
 def print_winner2():
     """print_winner identifies Charlie as winner of election"""
     out = check50.run("./plurality_test 0 9").stdout()
@@ -94,6 +100,7 @@ def print_winner3():
     result = check50.run("./plurality_test 0 10").stdout()
     if set(result.split("\n")) - {""} != {"Alice", "Bob"}:
         raise check50.Mismatch("Alice\nBob\nCharlie\n", result)
+
 
 @check50.check(compiles)
 @check50.hidden("print_winner function did not print all three winners of election")
@@ -120,5 +127,5 @@ def check_winner(result, correct):
             help = "did you print a space instead of a newline?"
         else:
             help = "did you forget the newline after the name?"
-    
+
     raise check50.Mismatch(correct, result, help=help)

--- a/plurality/__init__.py
+++ b/plurality/__init__.py
@@ -64,22 +64,28 @@ def invalid_vote_votes_unchanged():
     check50.run("./plurality_test 0 6").stdout("2 8 0").exit(0)
 
 @check50.check(compiles)
-@check50.hidden("print_winner function did not print winner of election")
+# @check50.hidden("print_winner function did not print winner of election")
 def print_winner0():
     """print_winner identifies Alice as winner of election"""
-    check50.run("./plurality_test 0 7").stdout("^Alice\n?$").exit(0)
+    out = check50.run("./plurality_test 0 7").stdout()
+    check_winner(out, "Alice\n")
+
 
 @check50.check(compiles)
-@check50.hidden("print_winner function did not print winner of election")
+# @check50.hidden("print_winner function did not print winner of election")
 def print_winner1():
     """print_winner identifies Bob as winner of election"""
-    check50.run("./plurality_test 0 8").stdout("^Bob\n?$").exit(0)
+    out = check50.run("./plurality_test 0 8").stdout()
+    check_winner(out, "Bob\n")
+
 
 @check50.check(compiles)
-@check50.hidden("print_winner function did not print winner of election")
+# @check50.hidden("print_winner function did not print winner of election")
 def print_winner2():
     """print_winner identifies Charlie as winner of election"""
-    check50.run("./plurality_test 0 9").stdout("^Charlie\n?$").exit(0)
+    out = check50.run("./plurality_test 0 9").stdout()
+    check_winner(out, "Charlie\n")
+
 
 @check50.check(compiles)
 @check50.hidden("print_winner function did not print both winners of election")
@@ -96,3 +102,23 @@ def print_winner4():
     result = check50.run("./plurality_test 0 11").stdout()
     if set(result.split("\n")) - {""} != {"Alice", "Bob", "Charlie"}:
         raise check50.Mismatch("Alice\nBob\nCharlie\n", result)
+
+
+# Note that check needs to be unhidden in order for help to be displayed
+def check_winner(result, correct):
+    if result == correct:
+        return
+
+    help = None
+    r = result.rstrip()
+    c = correct.rstrip()
+    if r == c:
+        if result[-1] == "\n":
+            if result[-2].isspace():
+                help = "did you print an extra space?"
+        elif result[-1].isspace():
+            help = "did you print a space instead of a newline?"
+        else:
+            help = "did you forget the newline after the name?"
+    
+    raise check50.Mismatch(correct, result, help=help)


### PR DESCRIPTION
Added new `check_winners` function to show help for the 3 individual print winner tests.  Had to unhide the tests in order for it to work, since the `@hidden` decorator means that the log isn't created and the help is never shown.   Having the actual help text might now be a bit redundant since the check will now show the expected vs result and it should be obvious.    (But we can't just unhide the checks as they were because the expected string includes the regex).  
@CarterZenke if too redundant, we can just call the `check_winner` function and if they don't match, simply raise the Mismatch with no help:

```
def check_winner(result, correct):
    if result == correct:
        return
    raise check50.Mismatch(correct, result)
```
I'm inclined to keep the help messages anyway.