### PR TITLE
New check for pset 2 - Wordle. Resolves #192

### DIFF
--- a/tideman/testing.c
+++ b/tideman/testing.c
@@ -62,12 +62,12 @@ int main(int argc, string argv[])
             preferences[2][0] = 2;
             preferences[2][1] = 5;
             preferences[2][2] = 0;
-            pairs[0].winner = 0;
+            pairs[0].winner = 2;
             pairs[0].loser = 1;
             pairs[1].winner = 0;
-            pairs[1].loser = 2;
-            pairs[2].winner = 2;
-            pairs[2].loser = 1;
+            pairs[1].loser = 1;
+            pairs[2].winner = 0;
+            pairs[2].loser = 2;
             break;
 
         case 4:

--- a/tideman/testing.c
+++ b/tideman/testing.c
@@ -62,12 +62,12 @@ int main(int argc, string argv[])
             preferences[2][0] = 2;
             preferences[2][1] = 5;
             preferences[2][2] = 0;
-            pairs[0].winner = 2;
+            pairs[0].winner = 0;
             pairs[0].loser = 1;
             pairs[1].winner = 0;
-            pairs[1].loser = 1;
-            pairs[2].winner = 0;
-            pairs[2].loser = 2;
+            pairs[1].loser = 2;
+            pairs[2].winner = 2;
+            pairs[2].loser = 1;
             break;
 
         case 4:

--- a/wordle/__init__.py
+++ b/wordle/__init__.py
@@ -93,6 +93,13 @@ def partial_match_exact_and_close():
     for word in ["agent", "burst", "canoe"]:
         check50.c.run(f"./wordle_test check_word arise {word}").stdout(3)
 
+
+@check50.check(compiles)
+def partial_match_repeat_guessed_letter():
+    """wordle recognizes guess with a repeat letter"""
+    for word in ["joust", "pines", "links"]:
+        check50.c.run(f"./wordle_test check_word grass {word}").stdout(3)
+      
         
 @check50.check(compiles)
 def partial_multiple_matches():


### PR DESCRIPTION
This check ensures the proper iteration implementation of check_word. Incorrectly looping through the choice rather than the guess could cause the program to miss the second letter. 

This is clear when comparing the guess 'grass' to the choice 'joust.' When you loop through joust, the code finds an exact match between the 4th letter and breaks. However, the code never compared the 4th letter of 'joust' to the 5th letter of 'grass,' which should have been a close match, but instead gets labeled as wrong.

In addition, the current implementation of scoring is flawed and needs to be changed. If done, the check 'links' can be changed to the check 'sinks' for thoroughness.

https://github.com/cs50/problems/issues/192