### PR TITLE
Update __init__.py

### DIFF
--- a/carpet/__init__.py
+++ b/carpet/__init__.py
@@ -67,7 +67,7 @@ def replace_readline(contents: list[str]) -> list[str]:
             readline_count += 1
             line = re.sub(
                 r"readline\([^\v]*\)",
-                f"commandArgs(trailingOnly = TRUE)[{readline_count}]",
+                f"commandArgs(trailingOnly = TRUE)[{readline_count}])",
                 line,
             )
         modified_contents.append(line)


### PR DESCRIPTION
add missing `)` to close the as.integer function.  Was causing check50 to fail with this message: 
```error: unexpected symbol in:
"year <- as.integer(commandArgs(trailingOnly = TRUE)[1]
predicted_visitors"
Execution halted```