### PR TITLE
Fix issue in CS50R Northwest Air to account for floating point imprecision + other bugs

### DIFF
--- a/air/check_files/check_5.R
+++ b/air/check_files/check_5.R
@@ -68,7 +68,7 @@ if (any(table(air$county) > 1)) {
 }
 
 # Tibble contains highest emissions for each county
-if (!isTRUE(all.equal(sort(air$emissions) == sort(check_air$emissions)))) {
+if (!isTRUE(all.equal(sort(air$emissions), sort(check_air$emissions)))) {
   cat("air tibble does not contain highest emissions for each county")
   quit(status = 1)
 }

--- a/air/check_files/check_5.R
+++ b/air/check_files/check_5.R
@@ -68,7 +68,7 @@ if (any(table(air$county) > 1)) {
 }
 
 # Tibble contains highest emissions for each county
-if (!all(sort(air$emissions) == sort(check_air$emissions))) {
+if (!isTRUE(all.equal(sort(air$emissions) == sort(check_air$emissions)))) {
   cat("air tibble does not contain highest emissions for each county")
   quit(status = 1)
 }

--- a/air/check_files/check_6.R
+++ b/air/check_files/check_6.R
@@ -62,7 +62,7 @@ if (length(missing_columns) > 0) {
 }
 
 # Objects are equal
-if (!all.equal(air, check_air)) {
+if (!isTRUE(all.equal(air, check_air))) {
   cat("tibble in 6.RData contains rows that are out of order or different from what's expected")
   quit(status = 1)
 }

--- a/air/check_files/check_7.R
+++ b/air/check_files/check_7.R
@@ -62,7 +62,7 @@ if (length(missing_columns) > 0) {
 }
 
 # Objects are equal
-if (!all.equal(air, check_air)) {
+if (!isTRUE(all.equal(air, check_air))) {
   cat("tibble in 7.RData contains rows that are out of order or different from what's expected")
   quit(status = 1)
 }

--- a/zelda/check_files/check_2.R
+++ b/zelda/check_files/check_2.R
@@ -62,7 +62,7 @@ if (length(missing_columns) > 0) {
 }
 
 # Objects are equal
-if (!all.equal(zelda, check_zelda)) {
+if (!isTRUE(all.equal(zelda, check_zelda))) {
   differences <- which(!apply(zelda == check_zelda, 1, all))
   cat("tibble in 2.RData contains rows that are out of order or different from what's expected")
   quit(status = 1)

--- a/zelda/check_files/check_3.R
+++ b/zelda/check_files/check_3.R
@@ -62,7 +62,7 @@ if (length(missing_columns) > 0) {
 }
 
 # Objects are equal
-if (!all.equal(zelda, check_zelda)) {
+if (!isTRUE(all.equal(zelda, check_zelda))) {
   differences <- which(!apply(zelda == check_zelda, 1, all))
   cat("tibble in 3.RData contains rows that are out of order or different from what's expected")
   quit(status = 1)

--- a/zelda/check_files/check_4.R
+++ b/zelda/check_files/check_4.R
@@ -62,7 +62,7 @@ if (length(missing_columns) > 0) {
 }
 
 # Objects are equal
-if (!all.equal(zelda, check_zelda)) {
+if (!isTRUE(all.equal(zelda, check_zelda))) {
   differences <- which(!apply(zelda == check_zelda, 1, all))
   cat("tibble in 4.RData contains rows that are out of order or different from what's expected")
   quit(status = 1)

--- a/zelda/check_files/check_5.R
+++ b/zelda/check_files/check_5.R
@@ -62,7 +62,7 @@ if (length(missing_columns) > 0) {
 }
 
 # Objects are equal
-if (!all.equal(zelda, check_zelda)) {
+if (!isTRUE(all.equal(zelda, check_zelda))) {
   differences <- which(!apply(zelda == check_zelda, 1, all))
   cat("tibble in 5.RData contains rows that are out of order or different from what's expected")
   quit(status = 1)


### PR DESCRIPTION
Fixed an issue in `check_5.R` (air) to use `all.equal()` to account for floating point imprecision. Was causing `check50` to fail with "air tibble does not contain highest emissions for each county" when some numerics in `air$emissions` are not exactly equal to the ones in `check_5.RData`.

Fixed an issue in `check_2.R` (zelda), `check_3.R` (zelda), `check_4.R` (zelda), `check_5.R` (zelda), `check_5.R` (air), `check_6.R` (air), `check_7.R` (air) to use `isTRUE()` with `all.equal()`. When not equal, `all.equal()` does not return `FALSE` but instead a vector of differences. Was causing `check50` to fail with "invalid argument type".