### PR TITLE
issue 257 fix

### DIFF
--- a/bank/__init__.py
+++ b/bank/__init__.py
@@ -58,4 +58,4 @@ def testWhats_up():
 
 def regex(amount):
     """match amount, allowing for characters (not numbers) on either side"""
-    return fr'^[^\d]*{escape(amount)}[^\d]*$'
+    return fr'^([^\d](?<!\$None)(?<!\$nan))*{escape(amount)}([^\d](?<!\$None)(?<!\$nan))*$'


### PR DESCRIPTION
it's a mouthful, but changing the ending regex from 
`fr'^[^\d]*{escape(amount)}[^\d]*$'`
to
`fr'^([^\d](?<!\$None)(?<!\$nan))*{escape(amount)}([^\d](?<!\$None)(?<!\$nan))*$'`
catches the cases where extra numbers that don't look like numbers (i.e. $None and $nan) are printed