### PR TITLE
 Fix Working 9 to 5 import regex

### DIFF
--- a/working/__init__.py
+++ b/working/__init__.py
@@ -17,7 +17,7 @@ def libraries():
     """working.py does not import libraries other than sys and re"""
     with open("working.py", "r") as file:
         contents = file.read()
-        if search(r'(?<!#)(?<! )((import(?![ \t]*(re|sys)\b))|(\bfrom\b(?![ \t]*(re|sys)\b)))', contents):
+        if search(r'(?<!#)(?<! )(((?:^|\n\s*)\bimport(?![ \t]*(re|sys)\b))|((?:^|\n\s*)\bfrom\b(?![ \t]*(re|sys)\b)))', contents):
             raise check50.Failure("working.py imports libraries other than sys and re", help="Be sure only to use \"import re\" and \"import sys\", or \"from re import ...\" and \"from sys import ...\"")
 
 


### PR DESCRIPTION
Proposed change to the regex used allows the student to use the words "from" and "import" in contexts where this would not result in an import, such as in a named group in a pattern.

Fixes #267.