### PR TITLE
Fix 9.sql check in movies pset.

### DIFF
--- a/movies/__init__.py
+++ b/movies/__init__.py
@@ -125,7 +125,6 @@ def test9():
             "Rupert Grint",
             "Daniel Radcliffe",
             "Emma Watson",
-            "Emma Watson",
         ],
         ordered=True,
     )


### PR DESCRIPTION
Remove duplicate line in the result as the problem set states that "If a person appeared in more than one movie in 2004, they should only appear in your results once.".