### PR TITLE
issue301 fix

### DIFF
--- a/inheritance/__init__.py
+++ b/inheritance/__init__.py
@@ -17,7 +17,7 @@ def compiles():
 def compiles():
     """inheritance compiles"""
     check50.c.compile("inheritance.c", lcs50=True)
-    inheritance = re.sub("int\s+main", "int distro_main", open("inheritance.c").read())
+    inheritance = re.sub("int\s+main\(", "int distro_main(", open("inheritance.c").read())
     testing = open("testing.c").read()
     with open("inheritance_test.c", "w") as f:
         f.write(inheritance)

--- a/plurality/__init__.py
+++ b/plurality/__init__.py
@@ -14,7 +14,7 @@ def exists():
 def compiles():
     """plurality compiles"""
     check50.c.compile("plurality.c", lcs50=True)
-    plurality = re.sub("int\s+main", "int distro_main", open("plurality.c").read())
+    plurality = re.sub("int\s+main\(", "int distro_main(", open("plurality.c").read())
     testing = open("testing.c").read()
     with open("plurality_test.c", "w") as f:
         f.write(plurality)

--- a/runoff/__init__.py
+++ b/runoff/__init__.py
@@ -14,7 +14,7 @@ def exists():
 def compiles():
     """runoff compiles"""
     check50.c.compile("runoff.c", lcs50=True)
-    runoff = re.sub("int\s+main", "int distro_main", open("runoff.c").read())
+    runoff = re.sub("int\s+main\(", "int distro_main(", open("runoff.c").read())
     testing = open("testing.c").read()
     with open("runoff_test.c", "w") as f:
         f.write(runoff)

--- a/tideman/__init__.py
+++ b/tideman/__init__.py
@@ -14,7 +14,7 @@ def exists():
 def compiles():
     """tideman compiles"""
     check50.c.compile("tideman.c", lcs50=True)
-    tideman = re.sub("int\s+main", "int distro_main", open("tideman.c").read())
+    tideman = re.sub("int\s+main\(", "int distro_main(", open("tideman.c").read())
     testing = open("testing.c").read()
     with open("tideman_test.c", "w") as f:
         f.write(tideman)

--- a/wordle/__init__.py
+++ b/wordle/__init__.py
@@ -19,7 +19,7 @@ def compiles():
     check50.c.compile("wordle.c", lcs50=True)
 
     # Rename main function to "distro_main"
-    wordle = re.sub("int\s+main", "int distro_main", open("wordle.c").read())
+    wordle = re.sub("int\s+main\(", "int distro_main(", open("wordle.c").read())
 
     # Read testing file
     testing = open("testing.c").read()
@@ -99,7 +99,7 @@ def partial_match_repeat_letter():
     """wordle recognizes guess with a repeat letter"""
     for word in ["joust", "pines", "links"]:
         check50.c.run(f"./wordle_test check_word grass {word}").stdout(3)
-        
+
 @check50.check(compiles)
 def partial_multiple_matches():
     """wordle recognizes guess with multiple matches"""


### PR DESCRIPTION
changes the regex in __init__.py to match "int main(" instead of just "int main", the latter of which would cause problems on the off chance a student declared an integer variable with the first four letters as "main", like "main_value" or something. issue301 mentioned this in tideman, but to my eye this happened in inheritance, plurality, runoff, and wordle as well; this PR fixes it in all five