### PR TITLE
add monkeypatch for requests.request

### DIFF
--- a/bitcoin/testing.py
+++ b/bitcoin/testing.py
@@ -1,7 +1,3 @@
-import bitcoin
-import requests
-
-
 class FakeResponse:
     def __init__(self):
         self.status_code = 200
@@ -31,6 +27,7 @@ class FakeResponse:
         pass
 
 
+import requests
 def request(method, url, **kwargs):
     if method == "GET":
         return FakeResponse()
@@ -42,6 +39,7 @@ requests.get = lambda *args, **kwargs: FakeResponse()
 requests.request = request
 
 # Run bitcoin via import
+import bitcoin
 
 # Run bitcoin's main function if not via import
 try:

--- a/bitcoin/testing.py
+++ b/bitcoin/testing.py
@@ -31,8 +31,15 @@ class FakeResponse:
         pass
 
 
+def request(method, url, **kwargs):
+    if method == "GET":
+        return FakeResponse()
+    else:
+        return None
+
+
 requests.get = lambda *args, **kwargs: FakeResponse()
-requests.request = lambda *args, **kwargs: FakeResponse()
+requests.request = request
 
 # Run bitcoin via import
 

--- a/bitcoin/testing.py
+++ b/bitcoin/testing.py
@@ -1,3 +1,7 @@
+import bitcoin
+import requests
+
+
 class FakeResponse:
     def __init__(self):
         self.status_code = 200
@@ -27,11 +31,10 @@ class FakeResponse:
         pass
 
 
-import requests
 requests.get = lambda *args, **kwargs: FakeResponse()
+requests.request = lambda *args, **kwargs: FakeResponse()
 
 # Run bitcoin via import
-import bitcoin
 
 # Run bitcoin's main function if not via import
 try:

--- a/bitcoin/testing.py
+++ b/bitcoin/testing.py
@@ -28,11 +28,11 @@ class FakeResponse:
 
 
 import requests
-def request(method, url, **kwargs):
+def fake_request(method, url, **kwargs):
     if method == "GET":
         return FakeResponse()
     else:
-        return None
+        return requests.request(method, url, **kwargs)
 
 
 requests.get = lambda *args, **kwargs: FakeResponse()

--- a/bitcoin/testing.py
+++ b/bitcoin/testing.py
@@ -36,7 +36,7 @@ def fake_request(method, url, **kwargs):
 
 
 requests.get = lambda *args, **kwargs: FakeResponse()
-requests.request = request
+requests.request = fake_request
 
 # Run bitcoin via import
 import bitcoin


### PR DESCRIPTION
I've seen a few students calling requests.request instead of request.get. Both methods seem to receive the same response from an API. This adds a monkeypatch to handle that.