### PR TITLE
CS50p shirt check50 not robust

### DIFF
--- a/shirt/__init__.py
+++ b/shirt/__init__.py
@@ -26,6 +26,15 @@ def test_fewer_arguments():
 
 
 @check50.check(exists)
+def test_one_argument():
+    """shirt.py exits given one command-line argument"""
+    check50.include("muppet_01.jpg")
+    exit = check50.run("python3 shirt.py muppet_01.jpg").exit()
+    if exit == 0:
+        raise check50.Failure(f"Expected non-zero exit code.")
+
+
+@check50.check(exists)
 def test_invalid_extension():
     """shirt.py exits given a file without a .jpg, .jpeg, or .png extension"""
     check50.include("invalid_extension.bmp")
@@ -37,7 +46,7 @@ def test_invalid_extension():
 @check50.check(exists)
 def test_non_existent_file():
     """shirt.py exits given a non-existent file"""
-    exit = check50.run("python3 shirt.py non_existent_file.jpg").exit()
+    exit = check50.run("python3 shirt.py non_existent_file.jpg out.jpg").exit()
     if exit == 0:
         raise check50.Failure(f"Expected non-zero exit code.")
 


### PR DESCRIPTION
As mentioned in issue #196, the current test case for a non-existent input image is only using 1 command line argument. The function is not testing for one sole purpose, but rather 2 at once: incorrect command line args (which is already caught in a previous function), and non-existent input image. Therefore, a student could theoretically never raise a FileNotFoundError and would still pass the current check50 test as long as they handle incorrect # of arguments.

To fix this, I created a function to check for 1 valid command line argument and another function to check for a non-existent input image in an otherwise correct program execution command.