### PR TITLE
Tideman check50 invalid string cmp

### DIFF
--- a/tideman/testing.c
+++ b/tideman/testing.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 
 int main(int argc, string argv[])
 {
@@ -105,9 +106,13 @@ int main(int argc, string argv[])
     {
         case 0:
             ranks3[0] = ranks3[1] = ranks3[2] = 0;
-            printf("%s", vote(0, "Bob", ranks3) ? "true" : "false");
-            break;
 
+            // Creating a copy of string "Bob"
+            char *bob_cpy = malloc((strlen("Bob) + 1) * sizeof(char));
+            strcpy(bob_cpy, "Bob");
+            printf("%s", vote(0, bob_cpy, ranks3) ? "true" : "false");
+            free(bob_cpy);
+            break;
         case 1:
             ranks3[0] = ranks3[1] = ranks3[2] = 0;
             printf("%s", vote(0, "David", ranks3) ? "true" : "false");

--- a/tideman/testing.c
+++ b/tideman/testing.c
@@ -108,7 +108,7 @@ int main(int argc, string argv[])
             ranks3[0] = ranks3[1] = ranks3[2] = 0;
 
             // Creating a copy of string "Bob"
-            char *bob_cpy = malloc((strlen("Bob) + 1) * sizeof(char));
+            char *bob_cpy = malloc((strlen("Bob") + 1) * sizeof(char));
             strcpy(bob_cpy, "Bob");
             printf("%s", vote(0, bob_cpy, ranks3) ? "true" : "false");
             free(bob_cpy);


### PR DESCRIPTION
Related to issue #334.

The current testing script passes all cases if a student uses literal string comparison `==` in the `vote()` function instead of `strcmp()`.

I have updated the test case so that it creates a string "Bob" in a different memory location. Therefore, if pointer comparison `==` is used, the test case will no longer pass.