### PR TITLE
Inheritance PSET 5 -- Fixed bug where check50 would occasionally pass all tests even if the child only selected alleles from the first parent

### DIFF
--- a/inheritance/__init__.py
+++ b/inheritance/__init__.py
@@ -48,6 +48,11 @@ def inheritance_rules_3():
     check50.run("./inheritance_test").stdout(".*allele_true.*").exit(0)
 
 @check50.check(compiles_test)
+def inheritance_rules_4():
+    """create_family follows inheritance rules 4"""
+    check50.run("export CHECK50_STATIC_INHERITANCE_ENABLED=1 && ./inheritance_test").stdout(".*allele_true.*").exit(0)
+
+@check50.check(compiles_test)
 def frees_memory():
     """free_family results in no memory leakages"""
     check50.c.valgrind("./inheritance").exit(0)

--- a/inheritance/__init__.py
+++ b/inheritance/__init__.py
@@ -21,6 +21,7 @@ def compiles_test():
     inheritance = re.sub(r"int\s+main\(", "int distro_main(", open("inheritance.c").read())
     testing = open("testing.c").read()
     with open("inheritance_test.c", "w") as f:
+        f.write("#include <string.h>\n")
         f.write(inheritance)
         f.write("\n")
         f.write(testing)

--- a/inheritance/inheritance.c
+++ b/inheritance/inheritance.c
@@ -18,8 +18,7 @@ char random_allele();
 
 int main(void)
 {
-    // Seed random number generator
-    srand(time(0));
+    // Seed generation is in testing.c
 
     // Create a new family with three generations
     person *p = create_family(3);

--- a/inheritance/testing.c
+++ b/inheritance/testing.c
@@ -37,7 +37,20 @@ int check_size(person *p, int n)
 
 int main(void)
 {
-    srand(time(0));
+    // check50 incorporates an environment variable in case a deterministic
+    // testcase is needed. Set this variable to 1 in order to set a fixed seed.
+    // Otherwise, don't provide it or set it as anything other than 1, and the
+    // tests will be randomly generated.
+    char *mode = getenv("CHECK50_STATIC_INHERITANCE_ENABLED");
+    if (mode && strcmp(mode, "1") == 0)
+    {
+        srand(2); // fixed seed for deterministic tests
+    }
+    else
+    {
+        srand(time(0));
+    }
+
     person *p = create_family(3);
 
     printf(check_size(p, 3) ? "size_true " : "size_false ");


### PR DESCRIPTION
Related to #277.

In Inheritance, a new person's blood type is generated by setting their $i$​th allele to either one of the alleles of the $i$​th parent, for $i \in \{0, 1\}$. The choice of which allele from the parent is taken is a 50/50 random decision at runtime.

Because `check50` generates a single run of `create_family()`, and said generation uses a random seed based on the current time, the tests are not always deterministic. In #277's case, if we set the child's alleles to come from the same parent, there is a small, but significant probability that `check50` will pass, despite having an inheritance check to see whether the alleles of the child match the alleles of their parents, recursively, for the entire family tree. As an example, consider the example in which, after randomly generating a family, every parent shares the same alleles. Then, even though the child is really only selecting an allele from 1 parent, the inheritance check cannot catch this.

To fix this, we added a static, deterministic testcase that will always fail the inheritance check. We added an environment variable into the `.run()` function's arguments, and our code will now check whether or not such an environment variable was provided. If so, it will run our static testcase that will fail the inheritance check.