### PR TITLE
Update testing.c (add voter_count)

### DIFF
--- a/plurality/testing.c
+++ b/plurality/testing.c
@@ -75,6 +75,7 @@ int main(int argc, string argv[])
             candidates[0].votes = 8;
             candidates[1].votes = 2;
             candidates[2].votes = 0;
+            voter_count = 10;
             print_winner();
             break;
 
@@ -82,6 +83,7 @@ int main(int argc, string argv[])
             candidates[0].votes = 1;
             candidates[1].votes = 8;
             candidates[2].votes = 1;
+            voter_count = 10;
             print_winner();
             break;
 
@@ -89,6 +91,7 @@ int main(int argc, string argv[])
             candidates[0].votes = 1;
             candidates[1].votes = 8;
             candidates[2].votes = 9;
+            voter_count = 18;
             print_winner();
             break;
 
@@ -96,6 +99,7 @@ int main(int argc, string argv[])
             candidates[0].votes = 8;
             candidates[1].votes = 8;
             candidates[2].votes = 5;
+            voter_count = 21;
             print_winner();
             break;
 
@@ -103,6 +107,7 @@ int main(int argc, string argv[])
             candidates[0].votes = 8;
             candidates[1].votes = 8;
             candidates[2].votes = 8;
+            voter_count = 24;
             print_winner();
             break;
     }


### PR DESCRIPTION
A valid solution to `print_winner` uses `voter_count` but will fail `check50` as that variable is not populated.  This fix adds that value to the `print_winner` tests. Fixes #351