### PR TITLE
Exclude `__pycache__`, `node_modules`, and `venv` folders

### DIFF
--- a/project/.cs50.yml
+++ b/project/.cs50.yml
@@ -1,5 +1,8 @@
 submit50:
   files: &submit50_files
+    - !exclude "__pycache__"
+    - !exclude "node_modules"
+    - !exclude "venv"
     - !require README.md
     - !require project.py
     - !require test_project.py


### PR DESCRIPTION
Fixes #357 