### PR TITLE
Matched values in FakeResponse.text to return from json

### DIFF
--- a/bitcoin/testing.py
+++ b/bitcoin/testing.py
@@ -8,7 +8,7 @@ import types
 class FakeResponse:
     def __init__(self):
         self.status_code = 200
-        self.text = '{"data":{"id":"bitcoin","rank":"1","symbol":"BTC","name":"Bitcoin","supply":"19823321.0000000000000000","maxSupply":"21000000.0000000000000000","marketCapUsd":"1942459024350.7046787559053215","volumeUsd24Hr":"12485110012.7294932098393723","priceUsd":"97988.5774109547375415","changePercent24Hr":"2.0282219564598007","vwap24Hr":"96203.8859537212418977","explorer":"https://blockchain.info/"},"timestamp":1739400157767}'
+        self.text = '{"data":{"id":"bitcoin","rank":"1","symbol":"BTC","name":"Bitcoin","supply":"19823321.0000000000000000","maxSupply":"21000000.0000000000000000","marketCapUsd":"1939613325892.4607145113457500","volumeUsd24Hr":"12341417371.3505338276601668","priceUsd":"97845.0243","changePercent24Hr":"1.4324165997531723","vwap24Hr":"96203.8859537212418977","explorer":"https://blockchain.info/"},"timestamp":1739399343596}'
 
     def json(*args):
         return {


### PR DESCRIPTION
The text in the FakeResonse was not matching the json returned by the mocked json method. Live response from the API shows that these values match. A student with some Python experience was using the json library to convert the text into the data for their solution. Check50 showed the slightly differing results vs the expected data from the FakeResponse. This gave little direction to fix the issue, beyond "follow the hints", which solved the issue.

I changed the values in the text section to match the response. To be thorough, I copied both to files and used python to compare. I ran a check50 test on a new version of bitcoin.py that uses the json library to verify.