### PR TITLE
Update regex to allow 'IF NOT EXISTS' in view creation

### DIFF
--- a/bnb/__init__.py
+++ b/bnb/__init__.py
@@ -181,7 +181,7 @@ def test_view(db: SQL, filename: Path) -> None:
 
         # Check for intent
         if not re.search(
-            rf'CREATE\s+VIEW\s+"?{re.escape(view_name)}"?', statement, re.IGNORECASE
+            rf'CREATE\s+VIEW\s+(?:IF NOT EXISTS)\s+"?{re.escape(view_name)}"?', statement, re.IGNORECASE
         ):
             raise check50.Failure(
                 f'{filename} does not create a view named "{view_name}"'


### PR DESCRIPTION
Currently fails if the student includes the `IF NOT EXISTS` phrase in their `CREATE` statement. This change allows that as an option.