### PR TITLE
Update backdrop validation so that 3 backdrops is accepted

### DIFF
--- a/build/__init__.py
+++ b/build/__init__.py
@@ -47,8 +47,8 @@ def three_backdrops(project):
 
     num_backdrops = parse_blocks(project)["backdrops"]
 
-    if num_backdrops < 3:
-        raise check50.Failure(f"only {num_backdrops} backdrop{'' if num_backdrops == 1 else 's'} found, at least 2 required")
+    if num_backdrops < 2:
+        raise check50.Failure(f"only {num_backdrops + 1} additional backdrop{'' if num_backdrops == 1 else 's'} found, at least 2 required")
 
 
 @check50.check(valid)


### PR DESCRIPTION
It was rejecting 3 backdrops. fixed the condition.  (the backdrop count is always 1 fewer than there are because count_costumes subtracts 1.)